### PR TITLE
Fix port conflict check

### DIFF
--- a/daemon/tasks/tunnel.go
+++ b/daemon/tasks/tunnel.go
@@ -14,6 +14,8 @@ import (
 	"github.com/besrabasant/ssh-tunnel-manager/utils"
 )
 
+var randomPortGenerator = generateRandomPort
+
 func StartTunnelTask(ctx context.Context, req *rpc.StartTunnelRequest, manager *tunnelmanager.TunnelManager) (*rpc.StartTunnelResponse, error) {
 	var output strings.Builder
 	manager.CreateResultChannels()
@@ -42,7 +44,7 @@ func StartTunnelTask(ctx context.Context, req *rpc.StartTunnelRequest, manager *
 
 	if localPort == 0 {
 		// Generate random port
-		randomPort, err := generateRandomPort()
+		randomPort, err := randomPortGenerator()
 		if err != nil {
 			return nil, fmt.Errorf("couldn't generate a random port: %v", err)
 		}
@@ -54,14 +56,14 @@ func StartTunnelTask(ctx context.Context, req *rpc.StartTunnelRequest, manager *
 
 		portBusy := false
 		for port := range manager.Connections {
-			if port == int(req.LocalPort) {
+			if port == int(localPort) {
 				portBusy = true
 				break
 			}
 		}
 
 		if portBusy {
-			output.WriteString(fmt.Sprint("\nCannot start tunnel as connection is already open on port ", req.LocalPort, "\n"))
+			output.WriteString(fmt.Sprintf("\nCannot start tunnel as connection is already open on port %d (requested %d)\n", localPort, req.LocalPort))
 			return &rpc.StartTunnelResponse{Result: output.String()}, nil
 		}
 	}

--- a/daemon/tasks/tunnel_test.go
+++ b/daemon/tasks/tunnel_test.go
@@ -1,0 +1,93 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/besrabasant/ssh-tunnel-manager/config"
+	"github.com/besrabasant/ssh-tunnel-manager/pkg/configmanager"
+	"github.com/besrabasant/ssh-tunnel-manager/pkg/tunnelmanager"
+	"github.com/besrabasant/ssh-tunnel-manager/rpc"
+)
+
+func createConfig(t *testing.T, dir string, entry configmanager.Entry) {
+	t.Helper()
+	// ensure directory exists
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	file, err := json.MarshalIndent(entry, "", " ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, entry.Name+".json"), file, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func TestStartTunnelTask_ConflictWithConfigPort(t *testing.T) {
+	tmp := t.TempDir()
+	os.Setenv(config.ConfigDirFlagName, tmp)
+	defer os.Unsetenv(config.ConfigDirFlagName)
+
+	entry := configmanager.Entry{
+		Name:       "test",
+		Server:     "server:22",
+		User:       "user",
+		KeyFile:    "key",
+		RemoteHost: "remote",
+		RemotePort: 22,
+		LocalPort:  5432,
+	}
+	createConfig(t, tmp, entry)
+
+	manager := tunnelmanager.NewTunnelManager()
+	manager.Connections[5432] = &tunnelmanager.ConnectionInfo{}
+
+	req := &rpc.StartTunnelRequest{ConfigName: "test", LocalPort: -1}
+	resp, err := StartTunnelTask(context.Background(), req, manager)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(resp.Result, "already open on port 5432") {
+		t.Fatalf("expected conflict message, got %q", resp.Result)
+	}
+}
+
+func TestStartTunnelTask_ConflictWithRandomPort(t *testing.T) {
+	tmp := t.TempDir()
+	os.Setenv(config.ConfigDirFlagName, tmp)
+	defer os.Unsetenv(config.ConfigDirFlagName)
+
+	entry := configmanager.Entry{
+		Name:       "test",
+		Server:     "server:22",
+		User:       "user",
+		KeyFile:    "key",
+		RemoteHost: "remote",
+		RemotePort: 22,
+		LocalPort:  1111,
+	}
+	createConfig(t, tmp, entry)
+
+	manager := tunnelmanager.NewTunnelManager()
+	manager.Connections[5432] = &tunnelmanager.ConnectionInfo{}
+
+	// override randomPortGenerator
+	original := randomPortGenerator
+	randomPortGenerator = func() (int, error) { return 5432, nil }
+	defer func() { randomPortGenerator = original }()
+
+	req := &rpc.StartTunnelRequest{ConfigName: "test", LocalPort: 0}
+	resp, err := StartTunnelTask(context.Background(), req, manager)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(resp.Result, "already open on port 5432") {
+		t.Fatalf("expected conflict message, got %q", resp.Result)
+	}
+}


### PR DESCRIPTION
## Summary
- check resolved local port when detecting conflicts
- show resolved port in the conflict error message
- allow tests to override random port generation
- add tests covering -1 and 0 local port cases

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/google.golang.org/grpc/@v/v1.62.1.zip": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683fa7bc5534832fa1604c7c5aaa29c4