### PR TITLE
Fix systemd service description

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ cp -r scripts $HOME/.local/share/sshtm
 # Optional: Set up the application as a system service (for systems using systemd)
 cat <<EOF > $HOME/.config/systemd/user/sshtmd.service
 [Unit]
-Description=SSH Tunnnel manager Daemon
+Description=SSH Tunnel Manager Daemon
 
 [Service]
 Type=simple


### PR DESCRIPTION
## Summary
- fix typographical error in install script so the systemd unit description reads 'SSH Tunnel Manager Daemon'

## Testing
- `go test ./...` *(fails: downloading modules is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_683fab9071a8832fa7f69ee41c054e45