### PR TITLE
Implement tunnel persistence across daemon restarts

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,3 +13,5 @@ const Address = Host + ":" + Port
 const ConfigDirFlagName = "config-dir"
 
 const DefaultConfigDir = "~/.ssh-tunnel-manager"
+
+const ActiveTunnelsFile = "active_tunnels.json"

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -1,12 +1,19 @@
 package main
 
 import (
+	"context"
 	"log"
 	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
 
 	"github.com/besrabasant/ssh-tunnel-manager/config"
+	"github.com/besrabasant/ssh-tunnel-manager/daemon/tasks"
 	"github.com/besrabasant/ssh-tunnel-manager/pkg/tunnelmanager"
 	"github.com/besrabasant/ssh-tunnel-manager/rpc"
+	"github.com/besrabasant/ssh-tunnel-manager/utils"
 	"google.golang.org/grpc"
 )
 
@@ -20,14 +27,64 @@ func main() {
 
 	rpServer := &server{}
 	rpc.RegisterDaemonServiceServer(s, rpServer)
-	
-	m := tunnelmanager.NewTunnelManager() 
+
+	m := tunnelmanager.NewTunnelManager()
 	rpServer.RegisterTunnelManger(m)
-	
+
+	// restore tunnels that were active before restart
+	restoreTunnels(m)
+
+	// handle shutdown signals and persist tunnels
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-c
+		persistTunnels(m)
+		os.Exit(0)
+	}()
 
 	log.Printf("server listening at %v", lis.Addr())
 
 	if err := s.Serve(lis); err != nil {
+		persistTunnels(m)
 		log.Fatalf("failed to serve: %v", err)
+	}
+}
+
+func restoreTunnels(m *tunnelmanager.TunnelManager) {
+	dirpath := config.DefaultConfigDir
+	if v := os.Getenv(config.ConfigDirFlagName); v != "" {
+		dirpath = v
+	}
+	configdir, err := utils.ResolveDir(dirpath)
+	if err != nil {
+		log.Printf("failed to resolve config dir: %v", err)
+		return
+	}
+	activeFile := filepath.Join(configdir, config.ActiveTunnelsFile)
+	tunnels, err := tunnelmanager.LoadActiveTunnels(activeFile)
+	if err != nil {
+		log.Printf("failed to load active tunnels: %v", err)
+		return
+	}
+	for _, t := range tunnels {
+		if _, err := tasks.StartTunnelTask(context.Background(), &rpc.StartTunnelRequest{ConfigName: t.ConfigName, LocalPort: int32(t.LocalPort)}, m); err != nil {
+			log.Printf("failed to restore tunnel %s: %v", t.ConfigName, err)
+		}
+	}
+}
+
+func persistTunnels(m *tunnelmanager.TunnelManager) {
+	dirpath := config.DefaultConfigDir
+	if v := os.Getenv(config.ConfigDirFlagName); v != "" {
+		dirpath = v
+	}
+	configdir, err := utils.ResolveDir(dirpath)
+	if err != nil {
+		log.Printf("failed to resolve config dir: %v", err)
+		return
+	}
+	if err := m.SaveActiveTunnels(filepath.Join(configdir, config.ActiveTunnelsFile)); err != nil {
+		log.Printf("failed to save active tunnels: %v", err)
 	}
 }

--- a/daemon/tasks/tunnel.go
+++ b/daemon/tasks/tunnel.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/besrabasant/ssh-tunnel-manager/config"
@@ -90,6 +91,11 @@ loop:
 				errReceived = true
 			}
 		}
+	}
+
+	// persist running tunnels
+	if err := manager.SaveActiveTunnels(filepath.Join(configdir, config.ActiveTunnelsFile)); err != nil {
+		output.WriteString(fmt.Sprintf("Failed to persist active tunnels: %v\n", err))
 	}
 
 	return &rpc.StartTunnelResponse{Result: output.String()}, nil

--- a/pkg/tunnelmanager/active_tunnels.go
+++ b/pkg/tunnelmanager/active_tunnels.go
@@ -1,0 +1,50 @@
+package tunnelmanager
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// ActiveTunnel represents a tunnel that should be restored on restart.
+type ActiveTunnel struct {
+	ConfigName string `json:"config_name"`
+	LocalPort  int    `json:"local_port"`
+}
+
+// SaveActiveTunnels persists current active tunnels to the given file.
+func (m *TunnelManager) SaveActiveTunnels(path string) error {
+	tunnels := make([]ActiveTunnel, 0)
+	m.Mutex.Lock()
+	for port, ci := range m.Connections {
+		tunnels = append(tunnels, ActiveTunnel{ConfigName: ci.Config.Name, LocalPort: port})
+	}
+	m.Mutex.Unlock()
+
+	if len(tunnels) == 0 {
+		// remove file if no active tunnels
+		os.Remove(path)
+		return nil
+	}
+
+	data, err := json.MarshalIndent(tunnels, "", " ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+// LoadActiveTunnels reads persisted tunnels from the given file.
+func LoadActiveTunnels(path string) ([]ActiveTunnel, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []ActiveTunnel{}, nil
+		}
+		return nil, err
+	}
+	var tunnels []ActiveTunnel
+	if err := json.Unmarshal(b, &tunnels); err != nil {
+		return nil, err
+	}
+	return tunnels, nil
+}


### PR DESCRIPTION
## Summary
- persist active tunnels to a file
- restore tunnels on daemon start
- handle shutdown signals to save state

## Testing
- `go test ./...` *(fails: proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6852738e81bc832f805bd24eb676c198