### PR TITLE
Fix deadlock when killing tunnels

### DIFF
--- a/daemon/tasks/kill.go
+++ b/daemon/tasks/kill.go
@@ -39,12 +39,12 @@ func KillTunnelTask(ctx context.Context, req *rpc.KillTunnelRequest, manager *tu
 
 	if connInfo != nil {
 		manager.Mutex.Lock()
-		defer manager.Mutex.Unlock()
 
 		output.WriteString(fmt.Sprint("Closing existing connection on port ", connPort, " for ", connInfo.Config.Name, "\n"))
 
 		// If there's an existing connection on the same port, close it
 		connInfo.ClearConnection() // Cancel the context of the existing connection
+		manager.Mutex.Unlock()
 
 		output.WriteString(fmt.Sprintf("\nTunneling stopped %q <==> %q through %q\n", connInfo.LocalAddr, connInfo.RemoteAddr, connInfo.Config.Server))
 

--- a/daemon/tasks/kill_test.go
+++ b/daemon/tasks/kill_test.go
@@ -1,0 +1,38 @@
+package tasks
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/besrabasant/ssh-tunnel-manager/config"
+	"github.com/besrabasant/ssh-tunnel-manager/pkg/configmanager"
+	"github.com/besrabasant/ssh-tunnel-manager/pkg/tunnelmanager"
+	"github.com/besrabasant/ssh-tunnel-manager/rpc"
+)
+
+func TestKillTunnelTask_NoDeadlock(t *testing.T) {
+	tmp := t.TempDir()
+	os.Setenv(config.ConfigDirFlagName, tmp)
+	defer os.Unsetenv(config.ConfigDirFlagName)
+
+	manager := tunnelmanager.NewTunnelManager()
+	manager.Connections[1234] = &tunnelmanager.ConnectionInfo{
+		Config: configmanager.Entry{Name: "test"},
+		Cancel: func() {},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		KillTunnelTask(context.Background(), &rpc.KillTunnelRequest{LocalPort: 1234}, manager)
+		close(done)
+	}()
+
+	select {
+	case <-time.After(1 * time.Second):
+		t.Fatal("KillTunnelTask did not return")
+	case <-done:
+		// success
+	}
+}


### PR DESCRIPTION
## Summary
- unlock manager mutex before saving active tunnels to avoid deadlock
- add regression test ensuring KillTunnelTask returns

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68527881c6b4832faecfa7240a2b29a3